### PR TITLE
Adding Assembly Stub Output and Generating IRIDA Next-Compliant JSON Output

### DIFF
--- a/bin/irida-next-output.py
+++ b/bin/irida-next-output.py
@@ -25,6 +25,15 @@ def main(argv=None):
     )
     parser.add_argument("files", nargs="+")
     parser.add_argument(
+        "--summary-file",
+        action="store",
+        dest="summary_file",
+        type=str,
+        help="pipeline summary file",
+        default=None,
+        required=True,
+    )
+    parser.add_argument(
         "--json-output",
         action="store",
         dest="json_output",
@@ -41,6 +50,9 @@ def main(argv=None):
         sys.stderr.write(f"Error: --json-output [{json_output_file}] exists")
         return 1
 
+    # Not checking for the existance of the summary file
+    # because the path may be relative to the outdir, which we don't have here.
+
     input_files = args.files
     if isinstance(input_files, str):
         input_files = [input_files]
@@ -55,7 +67,7 @@ def main(argv=None):
         },
     }
 
-    output_metadata = {"files": {"samples": {}}, "metadata": {"samples": {}}}
+    output_metadata = {"files": {"global": [{"path": str(args.summary_file)}], "samples": {}}, "metadata": {"samples": {}}}
 
     for f in input_files:
         _open = get_open(f)

--- a/bin/irida-next-output.py
+++ b/bin/irida-next-output.py
@@ -64,7 +64,7 @@ def main(argv=None):
             output_metadata["files"]["samples"] |= sample_metadata["files"]["samples"]
             output_metadata["metadata"]["samples"] |= sample_metadata["metadata"]["samples"]
 
-    data_json = json.dumps(output_metadata, indent=4)
+    data_json = json.dumps(output_metadata, sort_keys=True, indent=4)
     _open = get_open(json_output_file)
     with _open(json_output_file, "wt") as oh:
         oh.write(data_json)

--- a/bin/irida-next-output.py
+++ b/bin/irida-next-output.py
@@ -67,7 +67,10 @@ def main(argv=None):
         },
     }
 
-    output_metadata = {"files": {"global": [{"path": str(args.summary_file)}], "samples": {}}, "metadata": {"samples": {}}}
+    output_metadata = {
+        "files": {"global": [{"path": str(args.summary_file)}], "samples": {}},
+        "metadata": {"samples": {}},
+    }
 
     for f in input_files:
         _open = get_open(f)

--- a/bin/simplify_irida_json.py
+++ b/bin/simplify_irida_json.py
@@ -8,12 +8,11 @@ from mimetypes import guess_type
 from functools import partial
 from pathlib import Path
 
-def flatten_dictionary(dictionary):
 
+def flatten_dictionary(dictionary):
     result = {}
 
     def flatten(item, name=""):
-
         if type(item) is dict:
             for component in item:
                 flatten(item[component], str(name) + str(component) + ".")
@@ -21,12 +20,13 @@ def flatten_dictionary(dictionary):
         elif type(item) is list:
             for i in range(len(item)):
                 flatten(item[i], str(name) + str(i + 1) + ".")  # i + 1 because biologists
-            
+
         else:
             result[str(name)[:-1]] = item  # [:-1] avoids the "." appended on the previous recursion
-    
+
     flatten(dictionary)
     return result
+
 
 def main():
     parser = argparse.ArgumentParser(
@@ -55,15 +55,15 @@ def main():
 
     # Handle GZIP and non-GZIP
     encoding = guess_type(json_input_file)[1]
-    open_file = partial(gzip.open, mode='rt') if encoding == 'gzip' else open  # partial (function pointer)
+    open_file = partial(gzip.open, mode="rt") if encoding == "gzip" else open  # partial (function pointer)
 
     with open_file(json_input_file) as input_file:
-            input_json = json.load(input_file)
+        input_json = json.load(input_file)
 
     # Flatten metadata:
     for sample in input_json["metadata"]["samples"]:
         input_json["metadata"]["samples"][sample] = flatten_dictionary(input_json["metadata"]["samples"][sample])
-    
+
     json_data = json.dumps(input_json, sort_keys=True, indent=4)
     with open(json_output_location, "w") as output_file:
         output_file.write(json_data)
@@ -71,6 +71,7 @@ def main():
     print("Output written to " + str(json_output_location) + "!")
 
     return 0
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/bin/simplify_irida_json.py
+++ b/bin/simplify_irida_json.py
@@ -3,6 +3,9 @@
 import json
 import argparse
 import sys
+import gzip
+from mimetypes import guess_type
+from functools import partial
 from pathlib import Path
 
 def flatten_dictionary(dictionary):
@@ -50,12 +53,12 @@ def main():
 
     json_input_file = args.input
 
-    with open(args.input, "r") as input_file:
-            input_json = json.load(input_file)
+    # Handle GZIP and non-GZIP
+    encoding = guess_type(json_input_file)[1]
+    open_file = partial(gzip.open, mode='rt') if encoding == 'gzip' else open  # partial (function pointer)
 
-    # Flatten files:
-    for sample in input_json["files"]["samples"]:
-        input_json["files"]["samples"][sample] = flatten_dictionary(input_json["files"]["samples"][sample])
+    with open_file(json_input_file) as input_file:
+            input_json = json.load(input_file)
 
     # Flatten metadata:
     for sample in input_json["metadata"]["samples"]:

--- a/bin/simplify_irida_json.py
+++ b/bin/simplify_irida_json.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+
+import json
+import argparse
+import sys
+from pathlib import Path
+
+def flatten_dictionary(dictionary):
+
+    result = {}
+
+    def flatten(item, name=""):
+
+        if type(item) is dict:
+            for component in item:
+                flatten(item[component], str(name) + str(component) + ".")
+
+        elif type(item) is list:
+            for i in range(len(item)):
+                flatten(item[i], str(name) + str(i + 1) + ".")  # i + 1 because biologists
+            
+        else:
+            result[str(name)[:-1]] = item  # [:-1] avoids the "." appended on the previous recursion
+    
+    flatten(dictionary)
+    return result
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Simplifies JSON files for use with IRIDA Next",
+        epilog="Example: python simplify_irida_json.py --json-output output.json input.json",
+    )
+    parser.add_argument("input")
+    parser.add_argument(
+        "--json-output",
+        action="store",
+        dest="json_output",
+        type=str,
+        help="JSON output file",
+        default=None,
+        required=True,
+    )
+
+    args = parser.parse_args()
+
+    json_output_location = Path(args.json_output)
+    if json_output_location.exists():
+        sys.stderr.write("Error: --json-output [{json_output_location}] exists!\n")
+        return 1
+
+    json_input_file = args.input
+
+    with open(args.input, "r") as input_file:
+            input_json = json.load(input_file)
+
+    # Flatten files:
+    for sample in input_json["files"]["samples"]:
+        input_json["files"]["samples"][sample] = flatten_dictionary(input_json["files"]["samples"][sample])
+
+    # Flatten metadata:
+    for sample in input_json["metadata"]["samples"]:
+        input_json["metadata"]["samples"][sample] = flatten_dictionary(input_json["metadata"]["samples"][sample])
+    
+    json_data = json.dumps(input_json, sort_keys=True, indent=4)
+    with open(json_output_location, "w") as output_file:
+        output_file.write(json_data)
+
+    print("Output written to " + str(json_output_location) + "!")
+
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -46,6 +46,14 @@ process {
         ]
     }
 
+    withName: IRIDA_NEXT_OUTPUT {
+        publishDir = [
+            path: { "${params.outdir}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
     withName: CUSTOM_DUMPSOFTWAREVERSIONS {
         publishDir = [
             path: { "${params.outdir}/pipeline_info" },

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -34,6 +34,14 @@ process {
         ]
     }
 
+    withName: GENERATE_SUMMARY {
+        publishDir = [
+            path: { ["${params.outdir}", "${params.summary_directory_name}"].join(File.separator) },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
     withName: CUSTOM_DUMPSOFTWAREVERSIONS {
         publishDir = [
             path: { "${params.outdir}/pipeline_info" },

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -26,6 +26,14 @@ process {
         ]
     }
 
+    withName: ASSEMBLY_STUB {
+        publishDir = [
+            path: { ["${params.outdir}", "${params.assembly_directory_name}"].join(File.separator) },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
     withName: CUSTOM_DUMPSOFTWAREVERSIONS {
         publishDir = [
             path: { "${params.outdir}/pipeline_info" },

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -32,7 +32,7 @@ process {
 
     withName: ASSEMBLY_STUB {
         publishDir = [
-            path: { ["${params.outdir}", "${assembly_directory_name}"].join(File.separator) },
+            path: { ["${params.outdir}", "${task.assembly_directory_name}"].join(File.separator) },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -40,7 +40,7 @@ process {
 
     withName: GENERATE_SUMMARY {
         publishDir = [
-            path: { ["${params.outdir}", "${summary_directory_name}"].join(File.separator) },
+            path: { ["${params.outdir}", "${task.summary_directory_name}"].join(File.separator) },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -12,6 +12,10 @@
 
 process {
 
+    // Publish directory names
+    assembly_directory_name = "assembly"
+    summary_directory_name = "summary"
+
     publishDir = [
         path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
         mode: params.publish_dir_mode,
@@ -28,7 +32,7 @@ process {
 
     withName: ASSEMBLY_STUB {
         publishDir = [
-            path: { ["${params.outdir}", "${params.assembly_directory_name}"].join(File.separator) },
+            path: { ["${params.outdir}", "${assembly_directory_name}"].join(File.separator) },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -36,7 +40,7 @@ process {
 
     withName: GENERATE_SUMMARY {
         publishDir = [
-            path: { ["${params.outdir}", "${params.summary_directory_name}"].join(File.separator) },
+            path: { ["${params.outdir}", "${summary_directory_name}"].join(File.separator) },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]

--- a/modules/local/assembly_stub/main.nf
+++ b/modules/local/assembly_stub/main.nf
@@ -1,0 +1,31 @@
+process ASSEMBLY_STUB {
+    tag "$meta.id"
+    label 'process_single'
+
+    input:
+    tuple val(meta), path(reads)
+
+    output:
+    path("*.assembly.fa.gz"), emit: assembly
+    path "versions.yml"     , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    cat <<EOF > ${prefix}.assembly.fa
+    >${meta.id}-stub-assembly
+    ACGTAACCGGTTAAACCCGGGTTTAAAACCCCGGGGTTTTAAAAACCCCCGGGGGTTTTT
+    EOF
+
+    gzip -n ${prefix}.assembly.fa
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        assembly_stub : 0.1
+    END_VERSIONS
+    """
+}

--- a/modules/local/assembly_stub/main.nf
+++ b/modules/local/assembly_stub/main.nf
@@ -6,8 +6,8 @@ process ASSEMBLY_STUB {
     tuple val(meta), path(reads)
 
     output:
-    path("*.assembly.fa.gz"), emit: assembly
-    path "versions.yml"     , emit: versions
+    tuple val(meta), path("*.assembly.fa.gz"), emit: assembly
+    path "versions.yml"                      , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -16,7 +16,7 @@ process ASSEMBLY_STUB {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    cat <<EOF > ${prefix}.assembly.fa
+    cat <<-EOF > ${prefix}.assembly.fa
     >${meta.id}-stub-assembly
     ACGTAACCGGTTAAACCCGGGTTTAAAACCCCGGGGTTTTAAAAACCCCCGGGGGTTTTT
     EOF
@@ -25,7 +25,7 @@ process ASSEMBLY_STUB {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        assembly_stub : 0.1
+        assembly_stub : 0.1.0.dev0
     END_VERSIONS
     """
 }

--- a/modules/local/assembly_stub/main.nf
+++ b/modules/local/assembly_stub/main.nf
@@ -2,6 +2,8 @@ process ASSEMBLY_STUB {
     tag "$meta.id"
     label 'process_single'
 
+    container 'docker.io/python:3.9.17'
+
     input:
     tuple val(meta), path(reads)
 

--- a/modules/local/generate_sample_json/main.nf
+++ b/modules/local/generate_sample_json/main.nf
@@ -1,4 +1,4 @@
-process SAMPLE_METADATA {
+process GENERATE_SAMPLE_JSON {
     tag "$meta.id"
     label 'process_single'
 
@@ -17,22 +17,22 @@ process SAMPLE_METADATA {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
+    def assembly_path = ["${params.outdir}", "assembly", "${assembly}"].join(File.separator)
     """
-    reads_1=`basename ${reads[0]}`
-    reads_2=`basename ${reads[1]}`
     cat <<-EOF > "${meta.id}.json"
     {
         "files": {
             "samples": {
                 "${meta.id}": {
-                    "assembly_contigs": "${assembly}"
+                    "assembly_contigs": "${assembly_path}"
                 }
             }
         },
         "metadata": {
             "samples": {
                 "${meta.id}": {
-                    "reads": ["\${reads_1}", "\${reads_2}"]
+                    "reads.1": "${reads[0]}",
+                    "reads.2": "${reads[1]}"
                 }
             }
         }

--- a/modules/local/generate_sample_json/main.nf
+++ b/modules/local/generate_sample_json/main.nf
@@ -17,7 +17,7 @@ process GENERATE_SAMPLE_JSON {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def assembly_path = ["${params.assembly_directory_name}", "${assembly}"].join(File.separator)
+    def assembly_path = ["${task.assembly_directory_name}", "${assembly}"].join(File.separator)
     """
     cat <<-EOF > "${meta.id}.json"
     {

--- a/modules/local/generate_sample_json/main.nf
+++ b/modules/local/generate_sample_json/main.nf
@@ -42,7 +42,7 @@ process GENERATE_SAMPLE_JSON {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        irida-next-output : 0.1.0.dev0
+        generate_sample_json : 0.1.0.dev0
     END_VERSIONS
     """
 }

--- a/modules/local/generate_sample_json/main.nf
+++ b/modules/local/generate_sample_json/main.nf
@@ -23,16 +23,17 @@ process GENERATE_SAMPLE_JSON {
     {
         "files": {
             "samples": {
-                "${meta.id}": {
-                    "assembly_contigs": "${assembly_path}"
-                }
+                "${meta.id}": [
+                    {
+                        "path": "${assembly_path}"
+                    }
+                ]
             }
         },
         "metadata": {
             "samples": {
                 "${meta.id}": {
-                    "reads.1": "${reads[0]}",
-                    "reads.2": "${reads[1]}"
+                    "reads": ["${reads[0]}", "${reads[1]}"]
                 }
             }
         }

--- a/modules/local/generate_sample_json/main.nf
+++ b/modules/local/generate_sample_json/main.nf
@@ -17,7 +17,7 @@ process GENERATE_SAMPLE_JSON {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def assembly_path = ["${params.outdir}", "assembly", "${assembly}"].join(File.separator)
+    def assembly_path = ["${params.assembly_directory_name}", "${assembly}"].join(File.separator)
     """
     cat <<-EOF > "${meta.id}.json"
     {

--- a/modules/local/generate_summary/main.nf
+++ b/modules/local/generate_summary/main.nf
@@ -1,0 +1,42 @@
+process GENERATE_SUMMARY {
+    label 'process_single'
+    container 'docker.io/python:3.9.17'
+
+    input:
+    val summaries
+
+    output:
+    path("summary.txt.gz"), emit: summary
+    path "versions.yml"   , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    exec:
+    def args = task.ext.args ?: ''    
+    def sorted_summaries = summaries.sort{ it[0].id }
+
+    // Generate summary text:
+    def summary_text = "IRIDANEXT-EXAMPLE-NF Pipeline Summary\n\nCOMPLETE!\n"
+
+    for (summary in sorted_summaries) {
+        summary_text += "\n${summary[0].id}:\n"
+        summary_text += "    reads.1: ${summary[1][0]}\n"
+        summary_text += "    reads.2: ${summary[1][1]}\n"
+        summary_text += "    assembly: ${summary[2]}\n"
+    }
+
+    // Create summary text file (GZIP):
+    summary_gzip_location = ["${task.workDir}", "summary.txt.gz"].join(File.separator)
+    outputStream = new FileOutputStream(summary_gzip_location)
+    gzipOutputStream = new java.util.zip.GZIPOutputStream(outputStream)
+    printWriter = new PrintWriter(gzipOutputStream)
+    printWriter.write(summary_text)
+    printWriter.close()
+
+    // Write a versions.yml file:
+    version_file_location = ["${task.workDir}", "versions.yml"].join(File.separator)
+    version_text = "\n\"${task.process}\":\n    generate_summary : 0.1.0.dev0\n"
+    version_file = new File(version_file_location)
+    version_file.write(version_text)
+}

--- a/modules/local/generate_summary/main.nf
+++ b/modules/local/generate_summary/main.nf
@@ -17,7 +17,7 @@ process GENERATE_SUMMARY {
     def sorted_summaries = summaries.sort{ it[0].id }
 
     // Generate summary text:
-    def summary_text = "IRIDANEXT-EXAMPLE-NF Pipeline Summary\n\nCOMPLETE!\n"
+    def summary_text = "IRIDANEXT-EXAMPLE-NF Pipeline Summary\n\nSUCCESS!\n"
 
     for (summary in sorted_summaries) {
         summary_text += "\n${summary[0].id}:\n"

--- a/modules/local/generate_summary/main.nf
+++ b/modules/local/generate_summary/main.nf
@@ -7,18 +7,20 @@ process GENERATE_SUMMARY {
 
     output:
     path("summary.txt.gz"), emit: summary
-    path "versions.yml"   , emit: versions
+    path "versions.yml", emit: versions
 
     when:
     task.ext.when == null || task.ext.when
 
-    exec:
+    script:
     def args = task.ext.args ?: ''    
     def sorted_summaries = summaries.sort{ it[0].id }
 
     // Generate summary text:
     def summary_text = "IRIDANEXT-EXAMPLE-NF Pipeline Summary\n\nSUCCESS!\n"
 
+    // TODO: Consider the possibility of code injection.
+    // Should probably be moved to file processing through Python.
     for (summary in sorted_summaries) {
         summary_text += "\n${summary[0].id}:\n"
         summary_text += "    reads.1: ${summary[1][0]}\n"
@@ -26,23 +28,11 @@ process GENERATE_SUMMARY {
         summary_text += "    assembly: ${summary[2]}\n"
     }
 
-    // Create summary text file (GZIP):
-    work_dir_location = "${task.workDir}"
-    work_dir_file = new File(work_dir_location)
-    println "WORK DIR: " + work_dir_location
-    println "EXISTS? : " + work_dir_file.exists()
-    println "DIRECTORY? :" + work_dir_file.isDirectory()
+    version_text = "\"${task.process}\":\n    generate_summary : 0.1.0.dev0"
 
-    summary_gzip_location = ["${task.workDir}", "summary.txt.gz"].join(File.separator)
-    outputStream = new FileOutputStream(summary_gzip_location)
-    gzipOutputStream = new java.util.zip.GZIPOutputStream(outputStream)
-    printWriter = new PrintWriter(gzipOutputStream)
-    printWriter.write(summary_text)
-    printWriter.close()
-
-    // Write a versions.yml file:
-    version_file_location = ["${task.workDir}", "versions.yml"].join(File.separator)
-    version_text = "\n\"${task.process}\":\n    generate_summary : 0.1.0.dev0\n"
-    version_file = new File(version_file_location)
-    version_file.write(version_text)
+    """
+    echo "${summary_text}" > summary.txt
+    gzip -n summary.txt
+    echo "${version_text}" > versions.yml
+    """
 }

--- a/modules/local/generate_summary/main.nf
+++ b/modules/local/generate_summary/main.nf
@@ -13,7 +13,7 @@ process GENERATE_SUMMARY {
     task.ext.when == null || task.ext.when
 
     script:
-    def args = task.ext.args ?: ''    
+    def args = task.ext.args ?: ''
     def sorted_summaries = summaries.sort{ it[0].id }
 
     // Generate summary text:

--- a/modules/local/generate_summary/main.nf
+++ b/modules/local/generate_summary/main.nf
@@ -27,6 +27,12 @@ process GENERATE_SUMMARY {
     }
 
     // Create summary text file (GZIP):
+    work_dir_location = "${task.workDir}"
+    work_dir_file = new File(work_dir_location)
+    println "WORK DIR: " + work_dir_location
+    println "EXISTS? : " + work_dir_file.exists()
+    println "DIRECTORY? :" + work_dir_file.isDirectory()
+
     summary_gzip_location = ["${task.workDir}", "summary.txt.gz"].join(File.separator)
     outputStream = new FileOutputStream(summary_gzip_location)
     gzipOutputStream = new java.util.zip.GZIPOutputStream(outputStream)

--- a/modules/local/irida-next-output/main.nf
+++ b/modules/local/irida-next-output/main.nf
@@ -7,7 +7,7 @@ process IRIDA_NEXT_OUTPUT {
     path(samples_data)
 
     output:
-    path("output.json.gz"), emit: output_json
+    path("iridanext.output.json.gz"), emit: output_json
     path "versions.yml", emit: versions
 
     when:
@@ -20,7 +20,7 @@ process IRIDA_NEXT_OUTPUT {
     irida-next-output.py \\
         $args \\
         --summary-file ${task.summary_directory_name}/summary.txt.gz \\
-        --json-output output.json.gz \\
+        --json-output iridanext.output.json.gz \\
         ${samples_data}
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/local/irida-next-output/main.nf
+++ b/modules/local/irida-next-output/main.nf
@@ -19,7 +19,7 @@ process IRIDA_NEXT_OUTPUT {
     """
     irida-next-output.py \\
         $args \\
-        --summary-file ${params.summary_directory_name}/summary.txt \\
+        --summary-file ${params.summary_directory_name}/summary.txt.gz \\
         --json-output output.json.gz \\
         ${samples_data}
 

--- a/modules/local/irida-next-output/main.nf
+++ b/modules/local/irida-next-output/main.nf
@@ -19,6 +19,7 @@ process IRIDA_NEXT_OUTPUT {
     """
     irida-next-output.py \\
         $args \\
+        --summary-file ${params.summary_directory_name}/summary.txt \\
         --json-output output.json.gz \\
         ${samples_data}
 

--- a/modules/local/irida-next-output/main.nf
+++ b/modules/local/irida-next-output/main.nf
@@ -19,7 +19,7 @@ process IRIDA_NEXT_OUTPUT {
     """
     irida-next-output.py \\
         $args \\
-        --summary-file ${params.summary_directory_name}/summary.txt.gz \\
+        --summary-file ${task.summary_directory_name}/summary.txt.gz \\
         --json-output output.json.gz \\
         ${samples_data}
 

--- a/modules/local/sample_metadata/main.nf
+++ b/modules/local/sample_metadata/main.nf
@@ -5,7 +5,7 @@ process SAMPLE_METADATA {
     container 'docker.io/python:3.9.17'
 
     input:
-    tuple val(meta), path(reads)
+    tuple val(meta), path(reads), path(assembly)
 
     output:
     tuple val(meta), path("*.json.gz"), emit: json
@@ -23,7 +23,11 @@ process SAMPLE_METADATA {
     cat <<-EOF > "${meta.id}.json"
     {
         "files": {
-            "samples": {}
+            "samples": {
+                "${meta.id}": {
+                    "assembly_contigs": "${assembly}"
+                }
+            }
         },
         "metadata": {
             "samples": {

--- a/modules/local/simplify_irida_json/main.nf
+++ b/modules/local/simplify_irida_json/main.nf
@@ -1,0 +1,39 @@
+process SIMPLIFY_IRIDA_JSON {
+    tag "$meta.id"
+    label 'process_single'
+
+    container 'docker.io/python:3.9.17'
+
+    input:
+    tuple val(meta), path(json)
+
+    output:
+    tuple val(meta), path("*.simple.json.gz")  , emit: simple_json
+    path "versions.yml"                        , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def is_gzipped = json.getName().endsWith(".gz") ? true : false
+    def json_uncompressed_name = json.getName().replace(".gz", "")
+    """
+    if [ "$is_gzipped" = "true" ]; then
+        gzip -c -d $json > $json_uncompressed_name
+    fi
+
+    simplify_irida_json.py \\
+        $args \\
+        --json-output ${meta.id}.simple.json \\
+        ${json_uncompressed_name}
+
+    gzip ${meta.id}.simple.json
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        simplify_irida_json : 0.1.0.dev0
+    END_VERSIONS
+    """
+}

--- a/modules/local/simplify_irida_json/main.nf
+++ b/modules/local/simplify_irida_json/main.nf
@@ -17,17 +17,11 @@ process SIMPLIFY_IRIDA_JSON {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def is_gzipped = json.getName().endsWith(".gz") ? true : false
-    def json_uncompressed_name = json.getName().replace(".gz", "")
     """
-    if [ "$is_gzipped" = "true" ]; then
-        gzip -c -d $json > $json_uncompressed_name
-    fi
-
     simplify_irida_json.py \\
         $args \\
         --json-output ${meta.id}.simple.json \\
-        ${json_uncompressed_name}
+        ${json}
 
     gzip ${meta.id}.simple.json
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -51,8 +51,9 @@ params {
     validate_params                  = true
 
 
-    // Assembly stub
+    // Publish directories
     assembly_directory_name = "assembly"
+    summary_directory_name = "summary"
 }
 
 // Load base.config by default for all pipelines

--- a/nextflow.config
+++ b/nextflow.config
@@ -50,6 +50,9 @@ params {
     validationShowHiddenParams       = false
     validate_params                  = true
 
+
+    // Assembly stub
+    assembly_directory_name = "assembly"
 }
 
 // Load base.config by default for all pipelines

--- a/nextflow.config
+++ b/nextflow.config
@@ -49,11 +49,6 @@ params {
     validationSchemaIgnoreParams     = 'genomes,igenomes_base'
     validationShowHiddenParams       = false
     validate_params                  = true
-
-
-    // Publish directories
-    assembly_directory_name = "assembly"
-    summary_directory_name = "summary"
 }
 
 // Load base.config by default for all pipelines

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -245,14 +245,5 @@
             "$ref": "#/definitions/generic_options"
         }
     ],
-    "properties": {
-        "assembly_directory_name": {
-            "type": "string",
-            "default": "assembly"
-        },
-        "summary_directory_name": {
-            "type": "string",
-            "default": "summary"
-        }
-    }
+    "properties": {}
 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -244,5 +244,15 @@
         {
             "$ref": "#/definitions/generic_options"
         }
-    ]
+    ],
+    "properties": {
+        "assembly_directory_name": {
+            "type": "string",
+            "default": "assembly"
+        },
+        "summary_directory_name": {
+            "type": "string",
+            "default": "summary"
+        }
+    }
 }

--- a/workflows/iridanext.nf
+++ b/workflows/iridanext.nf
@@ -30,10 +30,10 @@ WorkflowIridanext.initialise(params, log)
 //
 // SUBWORKFLOW: Consisting of a mix of local and nf-core/modules
 //
-include { INPUT_CHECK       } from '../subworkflows/local/input_check'
-include { SAMPLE_METADATA   } from '../modules/local/sample_metadata/main'
-include { IRIDA_NEXT_OUTPUT } from '../modules/local/irida-next-output/main'
-include { ASSEMBLY_STUB     } from '../modules/local/assembly_stub/main'
+include { INPUT_CHECK          } from '../subworkflows/local/input_check'
+include { GENERATE_SAMPLE_JSON } from '../modules/local/generate_sample_json/main'
+include { IRIDA_NEXT_OUTPUT    } from '../modules/local/irida-next-output/main'
+include { ASSEMBLY_STUB        } from '../modules/local/assembly_stub/main'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -70,14 +70,14 @@ workflow IRIDANEXT {
     )
     ch_versions = ch_versions.mix(ASSEMBLY_STUB.out.versions)
 
-    SAMPLE_METADATA (
+    GENERATE_SAMPLE_JSON (
         input.join(ASSEMBLY_STUB.out.assembly)
     )
-    ch_versions = ch_versions.mix(SAMPLE_METADATA.out.versions)
-    sample_metadata_ch = SAMPLE_METADATA.out.json.map { meta, data -> data }.collect()
+    ch_versions = ch_versions.mix(GENERATE_SAMPLE_JSON.out.versions)
+    ch_sample_jsons = GENERATE_SAMPLE_JSON.out.json.map { meta, data -> data }.collect()
 
     IRIDA_NEXT_OUTPUT (
-        samples_data=sample_metadata_ch
+        samples_data=ch_sample_jsons
     )
     ch_versions = ch_versions.mix(IRIDA_NEXT_OUTPUT.out.versions)
 

--- a/workflows/iridanext.nf
+++ b/workflows/iridanext.nf
@@ -72,7 +72,7 @@ workflow IRIDANEXT {
     )
     ch_versions = ch_versions.mix(ASSEMBLY_STUB.out.versions)
 
-    // A channel of tuples of ([meta], [read[0], read[1]], assembly)
+    // A channel of tuples of ({meta}, [read[0], read[1]], assembly)
     ch_tuple_read_assembly = input.join(ASSEMBLY_STUB.out.assembly)
 
     GENERATE_SAMPLE_JSON (

--- a/workflows/iridanext.nf
+++ b/workflows/iridanext.nf
@@ -35,6 +35,7 @@ include { GENERATE_SAMPLE_JSON } from '../modules/local/generate_sample_json/mai
 include { SIMPLIFY_IRIDA_JSON  } from '../modules/local/simplify_irida_json/main'
 include { IRIDA_NEXT_OUTPUT    } from '../modules/local/irida-next-output/main'
 include { ASSEMBLY_STUB        } from '../modules/local/assembly_stub/main'
+include { GENERATE_SUMMARY     } from '../modules/local/generate_summary/main'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -71,10 +72,18 @@ workflow IRIDANEXT {
     )
     ch_versions = ch_versions.mix(ASSEMBLY_STUB.out.versions)
 
+    // A channel of tuples of ([meta], [read[0], read[1]], assembly)
+    ch_tuple_read_assembly = input.join(ASSEMBLY_STUB.out.assembly)
+
     GENERATE_SAMPLE_JSON (
-        input.join(ASSEMBLY_STUB.out.assembly)
+        ch_tuple_read_assembly
     )
     ch_versions = ch_versions.mix(GENERATE_SAMPLE_JSON.out.versions)
+
+    GENERATE_SUMMARY (
+        ch_tuple_read_assembly.collect{ [it] }
+    )
+    ch_versions = ch_versions.mix(GENERATE_SUMMARY.out.versions)
 
     SIMPLIFY_IRIDA_JSON (
         GENERATE_SAMPLE_JSON.out.json

--- a/workflows/iridanext.nf
+++ b/workflows/iridanext.nf
@@ -33,6 +33,7 @@ WorkflowIridanext.initialise(params, log)
 include { INPUT_CHECK       } from '../subworkflows/local/input_check'
 include { SAMPLE_METADATA   } from '../modules/local/sample_metadata/main'
 include { IRIDA_NEXT_OUTPUT } from '../modules/local/irida-next-output/main'
+include { ASSEMBLY_STUB     } from '../modules/local/assembly_stub/main'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -68,8 +69,13 @@ workflow IRIDANEXT {
         input
     )
     ch_versions = ch_versions.mix(SAMPLE_METADATA.out.versions)
-
     sample_metadata_ch = SAMPLE_METADATA.out.json.map { meta, data -> data }.collect()
+
+    ASSEMBLY_STUB (
+        input
+    )
+    ch_versions = ch_versions.mix(ASSEMBLY_STUB.out.versions)
+    
     IRIDA_NEXT_OUTPUT (
         samples_data=sample_metadata_ch
     )

--- a/workflows/iridanext.nf
+++ b/workflows/iridanext.nf
@@ -65,17 +65,17 @@ workflow IRIDANEXT {
                fastq_2 ? tuple(meta, [ file(fastq_1), file(fastq_2) ]) :
                tuple(meta, [ file(fastq_1) ])}
 
-    SAMPLE_METADATA (
-        input
-    )
-    ch_versions = ch_versions.mix(SAMPLE_METADATA.out.versions)
-    sample_metadata_ch = SAMPLE_METADATA.out.json.map { meta, data -> data }.collect()
-
     ASSEMBLY_STUB (
         input
     )
     ch_versions = ch_versions.mix(ASSEMBLY_STUB.out.versions)
-    
+
+    SAMPLE_METADATA (
+        input.join(ASSEMBLY_STUB.out.assembly)
+    )
+    ch_versions = ch_versions.mix(SAMPLE_METADATA.out.versions)
+    sample_metadata_ch = SAMPLE_METADATA.out.json.map { meta, data -> data }.collect()
+
     IRIDA_NEXT_OUTPUT (
         samples_data=sample_metadata_ch
     )

--- a/workflows/iridanext.nf
+++ b/workflows/iridanext.nf
@@ -32,6 +32,7 @@ WorkflowIridanext.initialise(params, log)
 //
 include { INPUT_CHECK          } from '../subworkflows/local/input_check'
 include { GENERATE_SAMPLE_JSON } from '../modules/local/generate_sample_json/main'
+include { SIMPLIFY_IRIDA_JSON  } from '../modules/local/simplify_irida_json/main'
 include { IRIDA_NEXT_OUTPUT    } from '../modules/local/irida-next-output/main'
 include { ASSEMBLY_STUB        } from '../modules/local/assembly_stub/main'
 
@@ -74,10 +75,15 @@ workflow IRIDANEXT {
         input.join(ASSEMBLY_STUB.out.assembly)
     )
     ch_versions = ch_versions.mix(GENERATE_SAMPLE_JSON.out.versions)
-    ch_sample_jsons = GENERATE_SAMPLE_JSON.out.json.map { meta, data -> data }.collect()
+
+    SIMPLIFY_IRIDA_JSON (
+        GENERATE_SAMPLE_JSON.out.json
+    )
+    ch_versions = ch_versions.mix(SIMPLIFY_IRIDA_JSON.out.versions)
+    ch_simplified_jsons = SIMPLIFY_IRIDA_JSON.out.simple_json.map { meta, data -> data }.collect() // Collect JSONs
 
     IRIDA_NEXT_OUTPUT (
-        samples_data=ch_sample_jsons
+        samples_data=ch_simplified_jsons
     )
     ch_versions = ch_versions.mix(IRIDA_NEXT_OUTPUT.out.versions)
 


### PR DESCRIPTION
- Adds stub assembly output.
- Generates a JSON file that is compatible with IRIDA Next.


Example single JSON output:

```
{
    "files": {
        "samples": {
            "SAMPLE1": [
                {
                    "path": "assembly/SAMPLE1.assembly.fa.gz"
                }
            ]
        }
    },
    "metadata": {
        "samples": {
            "SAMPLE1": {
                "reads": ["sample1_R1.fastq.gz", "sample1_R2.fastq.gz"]
            }
        }
    }
}

```

Example combined, flattened, and IRIDA-compliant JSON output:

```
{
    "files": {
        "global": [
            {
                "path": "summary/summary.txt.gz"
            }
        ],
        "samples": {
            "SAMPLE1": [
                {
                    "path": "assembly/SAMPLE1.assembly.fa.gz"
                }
            ],
            "SAMPLE2": [
                {
                    "path": "assembly/SAMPLE2.assembly.fa.gz"
                }
            ],
            "SAMPLE3": [
                {
                    "path": "assembly/SAMPLE3.assembly.fa.gz"
                }
            ]
        }
    },
    "metadata": {
        "samples": {
            "SAMPLE1": {
                "reads.1": "sample1_R1.fastq.gz",
                "reads.2": "sample1_R2.fastq.gz"
            },
            "SAMPLE2": {
                "reads.1": "sample2_R1.fastq.gz",
                "reads.2": "sample2_R2.fastq.gz"
            },
            "SAMPLE3": {
                "reads.1": "sample1_R1.fastq.gz",
                "reads.2": "null"
            }
        }
    }
}
```

Example summary file:

```
IRIDANEXT-EXAMPLE-NF Pipeline Summary

SUCCESS!

SAMPLE1:
    reads.1: /nf-core/test-datasets/viralrecon/illumina/amplicon/sample1_R1.fastq.gz
    reads.2: /nf-core/test-datasets/viralrecon/illumina/amplicon/sample1_R2.fastq.gz
    assembly: /nextflow-scratch/debeb133b9824ba8883d17261ce70f2f/a4/f892f61e24b5f7eaec584b044ce953/SAMPLE1.assembly.fa.gz

SAMPLE2:
    reads.1: /nf-core/test-datasets/viralrecon/illumina/amplicon/sample2_R1.fastq.gz
    reads.2: /nf-core/test-datasets/viralrecon/illumina/amplicon/sample2_R2.fastq.gz
    assembly: /nextflow-scratch/debeb133b9824ba8883d17261ce70f2f/cd/a2659b9486a06df86fbfa5ce8269bc/SAMPLE2.assembly.fa.gz

SAMPLE3:
    reads.1: /nf-core/test-datasets/viralrecon/illumina/amplicon/sample1_R1.fastq.gz
    reads.2: null
    assembly: /nextflow-scratch/debeb133b9824ba8883d17261ce70f2f/4a/d37e827094eb9c060c4c0be1a440af/SAMPLE3.assembly.fa.gz

```

Will very likely need to change how the summary file is written to avoid code injection: https://github.com/phac-nml/iridanext-example-nf/issues/10